### PR TITLE
force error's name and stack

### DIFF
--- a/src/stack-error.js
+++ b/src/stack-error.js
@@ -10,25 +10,24 @@ export default class StackError extends Error {
       }
 
       const funcs = words.reverse().map((word) => {
-        const func = new Function(
-          'funcs',
-          `
-        if (funcs.length > 0) {
-          const func = funcs[0];
-          func(funcs.slice(1));
-        } else {
-          throw new Error("↓");
-        }
-      `,
-        );
-        Object.defineProperty(func, 'name', { value: word });
-        return func;
+        return {
+          [word](funcs) {
+            if (funcs.length > 0) {
+              const func = funcs[0];
+              func(funcs.slice(1));
+            } else {
+              throw new Error("↓");
+            }
+          }
+        }[word];
       });
 
       const func = funcs[0];
       func(funcs.slice(1));
     } catch (error) {
       Object.setPrototypeOf(error, StackError.prototype);
+      error.name = 'StackError';
+      error.stack = error.stack.split('\n', words.length + 1).join('\n');
       return error;
     } finally {
       Error.stackTraceLimit = previousLimit;


### PR DESCRIPTION
force error's name and stack (on Firefox for example, this remove `<anonymous>` at the end when using the console)
also remove the usage of `new Function`